### PR TITLE
add support for scoring API

### DIFF
--- a/lib/zerobounce/request/v2_request.rb
+++ b/lib/zerobounce/request/v2_request.rb
@@ -18,6 +18,10 @@ module Zerobounce
         Response.new(get('validate', params), self)
       end
 
+      def score(params)
+        Response.new(get('scoring', params), self)
+      end
+
       private
 
       # @param [Hash] params


### PR DESCRIPTION
Add support for the scoring API (https://www.zerobounce.net/docs/ai-scoring-api/#single_email_scoring)

## Description
Mirror of the Validate API, just a different endpoint

## Motivation and Context
Enable checking the AI Score for a given email address.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
